### PR TITLE
Improve Safari compatibility for track player interactions

### DIFF
--- a/src/components/playerTrack.tsx
+++ b/src/components/playerTrack.tsx
@@ -49,15 +49,13 @@ export default function PlayerTrack({
     };
 
     // Slider change starts
-    const onSeekMouseDown = () => {
+    const onSeekStart = () => {
         setIsSeeking(true);
     };
 
     // Slider change ends and seek to new time
-    const onSeekMouseUp = (
-        e: React.MouseEvent<HTMLInputElement, MouseEvent>
-    ) => {
-        const newTime = parseFloat((e.target as HTMLInputElement).value);
+    const onSeekEnd = (e: React.PointerEvent<HTMLInputElement>) => {
+        const newTime = parseFloat(e.currentTarget.value);
         setIsSeeking(false);
         playerRef.current?.seekTo(newTime);
         setPlayedSeconds(newTime);
@@ -78,6 +76,7 @@ export default function PlayerTrack({
                         ref={playerRef}
                         url={track.link}
                         playing={isPlaying}
+                        playsinline
                         onDuration={handleDuration}
                         onProgress={handleProgress}
                         onEnded={handleEnd}
@@ -110,12 +109,13 @@ export default function PlayerTrack({
                             type='range'
                             min={0}
                             max={duration}
+                            step='any'
                             value={playedSeconds}
-                            onMouseDown={onSeekMouseDown}
+                            onPointerDown={onSeekStart}
                             onChange={(e) =>
                                 setPlayedSeconds(parseFloat(e.target.value))
                             }
-                            onMouseUp={onSeekMouseUp}
+                            onPointerUp={onSeekEnd}
                         />
                         <span className=''>{formatDuration(duration)}</span>
                     </div>


### PR DESCRIPTION
### Motivation
- Safari was not responding to range slider interactions and had playback quirks, causing the player to work in Chrome but fail on Safari; changes target input event handling and playback attributes to improve compatibility.

### Description
- Replace `onMouseDown`/`onMouseUp` with pointer events `onPointerDown`/`onPointerUp` and rename handlers to `onSeekStart`/`onSeekEnd` for better touch/mouse support.
- Use `e.currentTarget.value` in the seek-end handler to reliably read the slider value across browsers.
- Add `playsinline` to the `ReactPlayer` instance and set the range input `step='any'` for smoother and more consistent seeking.

### Testing
- Ran `npm run lint`, which failed due to an environment-specific issue where `next lint` resolves an invalid `/workspace/manonemusic/lint` directory.
- Ran `npm run build`, which compiled but failed to complete because Sanity configuration is missing (`projectId`), preventing a full build validation in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b1afb1da8c83318bbef45bab2250b8)