### PR TITLE
Use pointer events for seeking, enable fractional seeks and track-by-link in player list

### DIFF
--- a/src/components/playerTrack.tsx
+++ b/src/components/playerTrack.tsx
@@ -49,15 +49,13 @@ export default function PlayerTrack({
     };
 
     // Slider change starts
-    const onSeekMouseDown = () => {
+    const onSeekStart = () => {
         setIsSeeking(true);
     };
 
     // Slider change ends and seek to new time
-    const onSeekMouseUp = (
-        e: React.MouseEvent<HTMLInputElement, MouseEvent>
-    ) => {
-        const newTime = parseFloat((e.target as HTMLInputElement).value);
+    const onSeekEnd = (e: React.PointerEvent<HTMLInputElement>) => {
+        const newTime = parseFloat(e.currentTarget.value);
         setIsSeeking(false);
         playerRef.current?.seekTo(newTime);
         setPlayedSeconds(newTime);
@@ -78,6 +76,7 @@ export default function PlayerTrack({
                         ref={playerRef}
                         url={track.link}
                         playing={isPlaying}
+                        playsinline
                         onDuration={handleDuration}
                         onProgress={handleProgress}
                         onEnded={handleEnd}
@@ -110,12 +109,13 @@ export default function PlayerTrack({
                             type='range'
                             min={0}
                             max={duration}
+                            step='any'
                             value={playedSeconds}
-                            onMouseDown={onSeekMouseDown}
+                            onPointerDown={onSeekStart}
                             onChange={(e) =>
                                 setPlayedSeconds(parseFloat(e.target.value))
                             }
-                            onMouseUp={onSeekMouseUp}
+                            onPointerUp={onSeekEnd}
                         />
                         <span className=''>{formatDuration(duration)}</span>
                     </div>

--- a/src/components/playerTrackList.tsx
+++ b/src/components/playerTrackList.tsx
@@ -10,22 +10,20 @@ type PlayerTrackListProps = {
 };
 
 export default function PlayerTrackList({ tracks }: PlayerTrackListProps) {
-    const [currentlyPlaying, setCurrentlyPlaying] = useState<string | null>(
-        null
-    );
+    const [currentlyPlaying, setCurrentlyPlaying] = useState<string | null>(null);
 
-    const handleTrackClick = (clickedTrackTitle: string) => {
-        if (currentlyPlaying === clickedTrackTitle) {
+    const handleTrackClick = (clickedTrackLink: string) => {
+        if (currentlyPlaying === clickedTrackLink) {
             // If the clicked track is already playing, pause it.
             setCurrentlyPlaying(null);
         } else {
             // Play the clicked track and pause others
-            setCurrentlyPlaying(clickedTrackTitle);
+            setCurrentlyPlaying(clickedTrackLink);
         }
     };
 
-    const handleSlideClick = (clickedTrackTitle: string) => {
-        setCurrentlyPlaying(clickedTrackTitle);
+    const handleSlideClick = (clickedTrackLink: string) => {
+        setCurrentlyPlaying(clickedTrackLink);
     };
 
     return (
@@ -33,11 +31,11 @@ export default function PlayerTrackList({ tracks }: PlayerTrackListProps) {
             {tracks.map((track, index) => (
                 <PlayerTrack
                     index={index}
-                    key={track.trackname}
+                    key={`${track.link}-${index}`}
                     track={track}
-                    buttonAction={() => handleTrackClick(track.trackname)}
-                    sliderAction={() => handleSlideClick(track.trackname)}
-                    isPlaying={currentlyPlaying === track.trackname}
+                    buttonAction={() => handleTrackClick(track.link)}
+                    sliderAction={() => handleSlideClick(track.link)}
+                    isPlaying={currentlyPlaying === track.link}
                 />
             ))}
             {/* TODO add Soundcloud logo */}


### PR DESCRIPTION
### Motivation

- Improve seeking reliability and precision across input devices and avoid key collisions by using a stable identifier for tracks.
- Ensure the embedded player behaves correctly on mobile by enabling inline playback.

### Description

- Replace mouse-based seek handlers with pointer-based handlers by renaming to `onSeekStart`/`onSeekEnd` and switching to `onPointerDown`/`onPointerUp`, and use `e.currentTarget.value` to compute the seek time and call `playerRef.current?.seekTo`.
- Allow fractional seeking by adding `step='any'` to the range input and keep `onChange` updates using `parseFloat` on the input value.
- Add `playsinline` to the `ReactPlayer` instance to improve mobile playback behavior.
- Switch player identity in the list from `track.trackname` to `track.link` for state comparisons and set element keys to ``${track.link}-${index}`` to reduce collisions.

### Testing

- Ran TypeScript type-check with `tsc --noEmit`, which passed.
- Ran linting with `npm run lint`, which passed.
- Ran the test suite with `npm test`, which passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b1afb1da8c83318bbef45bab2250b8)